### PR TITLE
Add arm64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,7 +40,8 @@ jobs:
             type=sha
         # List of custom labels
         # labels: # optional
-
+        flavor: |
+          latest=auto
     - name: Docker Setup QEMU
       uses: docker/setup-qemu-action@v2.1.0
     

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,10 +2,18 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    tags:
+      - v*
 
+permissions: 
+  packages: write
+  
+env:
+  APP_NAME: scannarr
+  DOCKER_FILE: ./Dockerfile
+  DOCKER_PLATFORMS: "linux/arm64/v8,linux/amd64"
+  ENABLE_DOCKERHUB: 1
+  
 jobs:
 
   build:
@@ -13,6 +21,58 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      
+    - name: Docker Metadata action
+      id: meta
+      uses: docker/metadata-action@v4.3.0
+      with:
+        images: |
+          ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+        tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+        # List of custom labels
+        # labels: # optional
+
+    - name: Docker Setup QEMU
+      uses: docker/setup-qemu-action@v2.1.0
+    
+    - name: Docker Setup Buildx
+      uses: docker/setup-buildx-action@v2.5.0
+      with:
+        buildkitd-flags: --debug
+    
+    - name: Docker Login
+      if: ${{ github.event_name != 'pull_request' && env.ENABLE_DOCKERHUB == 1 }}
+      uses: docker/login-action@v2.1.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v4.0.0
+      with:
+        context: .
+        file: ${{ env.DOCKER_FILE }}
+        platforms: ${{ env.DOCKER_PLATFORMS }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Docker Hub Registry Description
+      if: ${{ env.ENABLE_DOCKERHUB == 1 }}
+      uses: peter-evans/dockerhub-description@v3.3.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+        short-description: |
+          a web interface to manage your torrents on Real-Debrid, AllDebrid or Premiumize.
+        readme-filepath: ./README.md

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,18 +30,19 @@ jobs:
       with:
         images: |
           ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.APP_NAME }}
+        flavor: |
+          latest=auto
         tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
         # List of custom labels
         # labels: # optional
-        flavor: |
-          latest=auto
+
     - name: Docker Setup QEMU
       uses: docker/setup-qemu-action@v2.1.0
     


### PR DESCRIPTION
Modified github action to add build and push support for arm64.  It's triggered by the creation of a tag named "v*"
Based on docker-image.yml action from the rdtclient repo.